### PR TITLE
update to add closing bracket in filter

### DIFF
--- a/docs/cookbooks/recipes/elasticstack.html
+++ b/docs/cookbooks/recipes/elasticstack.html
@@ -153,6 +153,7 @@
 <span class="go">        &quot;[type]&quot; =&gt; &quot;osseclogs&quot;</span>
 <span class="go">      }</span>
 <span class="go">    }</span>
+<span class="go">  }</span>
 <span class="go">}</span>
 
 <span class="go">output {</span>


### PR DESCRIPTION
Using the provided example will result in a compile_imperative error when restarting logstash. Just missing a closing "}" in the filter block.